### PR TITLE
Add Spiderhash to Debug JavaScript tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [DebugJS](http://debugjs.com/) - Debug your JavaScript in the browser (lol?)
 - [endpoints.dev](https://www.endpoints.dev) - View realtime HTTP requests using a endpoints.dev generated URL.
 - [httpbin](http://httpbin.org/) - HTTP Request & Response service.
+- [Spiderhash](https://spiderhash.io/) - Webhook inspection and debugging tool for capturing, replaying, and analyzing webhook deliveries.
 - [JavaScript Visualizer 9000](https://www.jsv9000.app) - Loupe-inspired JavaScript execution visualizer
 - [JSONBIN.io](https://jsonbin.io/quick-store) - Custom, mock JSON API
 - [Loupe](http://latentflip.com/loupe/) - Similar in goal to SlowmoJS, a JavaScript call stack visualizer.


### PR DESCRIPTION
## Summary\n- add Spiderhash to the Debug JavaScript section as a webhook inspection/debugging tool\n\n## Why\nSpiderhash helps developers capture and inspect webhook deliveries while testing integrations, which fits this list's in-browser devtool focus.