### PR TITLE
Add benchmarkstudio.net

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 
 ### Performance
 
+- [Benchmark Studio](https://benchmarkstudio.net/) - JS performance benchmarks
 - [Perflink](https://perf.link) - JS benchmarks
 
 ### Playgrounds


### PR DESCRIPTION
This PR is for adding [Benchmark Studio](https://benchmarkstudio.net), a tool that I've developed for JS performance benchmarking.

It meets the following criteria:

- **Browser-based** — no downloads or native app installs
- **Direct link** — goes straight to the tool (not a multi-tool landing page)
- **100% free** — no signups, trials, paywalls, or usage limits

It's similar in nature to a tool already posted (Perflink). However, it has a different feature set and perhaps a different use, as the focus is not _just_ on speed but also on statistical analysis of results for a more complete picture.