### PR TITLE
Add API Status Check to APIs section

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 
 ### APIs
 
+- [API Status Check](https://www.apistatuscheck.com) - Real-time status monitoring for 540+ APIs and services including AWS, Stripe, GitHub, and OpenAI.
 - [JSONPlaceholder](https://jsonplaceholder.typicode.com) - Free fake API for testing and prototyping.
 - [Zippopotamus](http://zippopotam.us/) - Zipcode to Geo
 


### PR DESCRIPTION
Adds [API Status Check](https://www.apistatuscheck.com) to the APIs section — a free, real-time status monitoring dashboard for 540+ developer APIs and services (AWS, Stripe, GitHub, OpenAI, Twilio, etc.).

Useful for developers who want to quickly check if a third-party API dependency is experiencing issues before debugging their own code.

Cherry-picked from the previous closed PR #279 per maintainer request.