### PR TITLE
Add EpochPilot to Transformation

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [ByteTools JWT Decoder](https://bytetools.io/jwt-decoder/) - Decode and inspect JSON Web Tokens securely. 100% client-side processing, never sends tokens to servers.
 - [ByteTools URL Encoder](https://bytetools.io/url-encoder/) - Encode and decode URLs safely. Perfect for handling query parameters and API endpoints.
 - [Compiler Explorer](https://godbolt.org) - Run compilers interactively from your web browser and interact with the assembly
+- [EpochPilot](https://epochpilot.com) - Convert Unix timestamps, compare timezones, and parse cron expressions. 100% client-side.
 - [fixmyjs](http://goatslacker.github.io/fixmyjs.com/) - Automatically fix your JS, driven by JSHint.
 - [JavaScript Deobfuscator](https://deobfuscate.io) - A simple but powerful deobfuscator to remove common JavaScript obfuscation techniques.
 - [JSONFormatOnline](https://jsonformatonline.com) - Format, validate and convert JSON locally in the browser, no data sent to servers.


### PR DESCRIPTION
Adding [EpochPilot](https://epochpilot.com) to the Web-based Tools > Transformation section.

EpochPilot converts Unix timestamps to human-readable dates, compares timezones side-by-side, and parses cron expressions with plain-English explanations.

- **Browser-based**: Runs entirely in-browser, no downloads or installs
- **Direct link**: Goes straight to the tool interface
- **100% free**: No signups, trials, paywalls, or usage limits
- **Privacy-first**: All calculations happen client-side, no data sent to any server

Disclosure: I am the creator of this tool.