### PR TITLE
Add Anytools JWT Decoder to Transformation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 
 ### Transformation
 
+- [Anytools JWT Decoder](https://anytools.io/dev/jwt-decoder) - Decode and inspect JWT header and payload client-side. Shows expiration status, claim details. Zero outbound requests — verify in DevTools Network tab.
 - [AST Explorer](http://astexplorer.net/) - Parse JS to an explorable AST tree via acorn, babel, babylon, espree, esprima, recast, shift, and typescript.
 - [Babel REPL](https://babeljs.io/en/repl) - The compiler for next generation JavaScript
 - [ByteTools JWT Decoder](https://bytetools.io/jwt-decoder/) - Decode and inspect JSON Web Tokens securely. 100% client-side processing, never sends tokens to servers.


### PR DESCRIPTION
Adds [Anytools JWT Decoder](https://anytools.io/dev/jwt-decoder) — a direct link to a single, specific tool as requested in #324.

- **Browser-based** — no downloads or native app installs
- **Direct link** — goes straight to the JWT decoder tool, not a landing page
- **100% free** — no signups, trials, paywalls, or usage limits

Decodes JWT header and payload entirely client-side. Zero outbound requests after page load — verifiable in DevTools Network tab.