### PR TITLE
Add Anytools Regex Tester to Regex section

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 
 ### Regex
 
+- [Anytools Regex Tester](https://anytools.io/dev/regex-tester) - Live JavaScript regex matching with capture group highlighting. 100% client-side, no data sent to servers.
 - [ByteTools Regex Test](https://bytetools.io/regex-tester/) - Free regex test tool with real-time matching, examples, and mobile optimization.
 - [Debuggex](https://www.debuggex.com/) - PCRE/Python/JavaScript regex matching.
 - [ExtendsClass](https://extendsclass.com/regex-tester.html) - PHP/Python/Ruby/JavaScript regex matching.


### PR DESCRIPTION
Adds [Anytools Regex Tester](https://anytools.io/dev/regex-tester) — a direct link to a single, specific tool.

- **Browser-based** — no downloads or native app installs
- **Direct link** — goes straight to the regex tester tool, not a landing page
- **100% free** — no signups, trials, paywalls, or usage limits

Live JavaScript regex matching with capture group highlighting. 100% client-side, no data sent to servers.