### PR TITLE
Add Free Background Remover to Image section

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 
 - [Clippy](https://bennettfeely.com/clippy) - CSS clip-path maker and editor.
 - [Favic-o-matic](http://www.favicomatic.com/) - Literally generates every favicon neccessary + markup.
+- [Free Background Remover](https://free-background-remover.com) - AI image background remover that runs entirely in the browser, no upload or sign-up.
 - [JPEG.rocks](https://jpeg.rocks) - Privacy-aware JPEG optimizer
 - [PNG-to-SVG](https://png-to-svg.com) - Free conversion from JPG or PNG images To vectorized SVG.
 - [Squoosh](https://squoosh.app/) - Compress and optimize images in browser


### PR DESCRIPTION
Adds Free Background Remover to the Image section. It is a browser-based AI background remover with a direct link, free, with no signups, paywalls, or usage limits, which matches the three contribution criteria in CONTRIBUTING.md. Sits alphabetically between Favic-o-matic and JPEG.rocks.