### PR TITLE
Add PostalCodes.info API resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 ### APIs
 
 - [JSONPlaceholder](https://jsonplaceholder.typicode.com) - Free fake API for testing and prototyping.
+- [PostalCodes.info](https://postalcodes.info/api) - Global postal code lookup API and downloadable datasets.
 - [Zippopotamus](http://zippopotam.us/) - Zipcode to Geo
 
 ### Browser Information


### PR DESCRIPTION
Adds PostalCodes.info to Resources > APIs.

It provides a direct, browser-accessible postal code lookup API plus downloadable datasets, which fits this section alongside Zippopotamus.