### PR TITLE
Add TinyTools to Generators

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [Sovereign README Forge](https://ryudi84.github.io/sovereign-tools/tools/readme_forge/) - Generate professional README files for your projects. Free, no signup required.
 - [Sovereign Shadow Forge](https://ryudi84.github.io/sovereign-tools/tools/shadow_forge/) - Design CSS box-shadows with a visual builder. Free, no signup required.
 - [Toolshref ZOD Schema Generator](https://toolshref.com/json-to-zod-schema-generator/) - Generate JSON to TypeScript Zod validation schemas instantly.
+- [TinyTools](https://tinytools-smoky.vercel.app/) - Free single-purpose browser-based generators (no signup): favicon, color palette, OG image, SEO meta tags, AI robots.txt, AI content disclosure, domain names, plus an AI cost calculator and a local AI background remover. Open source.
 - [Tools-Online Cron Generator](https://www.tools-online.app/tools/cron) - Visual cron expression builder with real-time preview and plain English descriptions. 100% client-side.
 - [ToolSparkr Password Generator](https://toolsparkr.com/password-generator) - Generate strong random passwords up to 128 characters with strength indicator. 100% client-side, no data sent to servers.
 - [ToolSparkr QR Code Reader](https://toolsparkr.com/qr-code-reader) - Generate and read QR codes online with adjustable size and error correction. Runs entirely in browser.


### PR DESCRIPTION
Adding [TinyTools](https://tinytools-smoky.vercel.app/) under **Web-based Tools → Generators**. It is a collection of single-purpose, browser-based generators that fit the section perfectly: no signup, no servers, everything runs client-side. Tools include favicon generator, color palette generator, OG image generator, SEO meta tag generator, AI robots.txt generator, AI content disclosure generator (EU AI Act compliant), domain name generator, AI cost calculator, and a local AI background remover. Open source.

Inserted alphabetically before the existing `Tools-Online` entry. Thanks for maintaining this list!