### PR TITLE
Add UUID Generator to Generators section

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [Sovereign Hash Forge](https://ryudi84.github.io/sovereign-tools/tools/hash_forge/) - Generate SHA-256, MD5, and other hashes in the browser. Free, no signup required.
 - [Sovereign Meta Forge](https://ryudi84.github.io/sovereign-tools/tools/meta_forge/) - Generate HTML meta tags for SEO optimization. Free, no signup required.
 - [Sovereign README Forge](https://ryudi84.github.io/sovereign-tools/tools/readme_forge/) - Generate professional README files for your projects. Free, no signup required.
+- [UUID Generator](https://freedevtool.org/uuid-generator) - Generate UUID v1, v4, v5, or v7 (RFC 9562) in browser. Bulk generation up to 1,000. Uses Web Crypto CSPRNG. No signup.
 - [Sovereign Shadow Forge](https://ryudi84.github.io/sovereign-tools/tools/shadow_forge/) - Design CSS box-shadows with a visual builder. Free, no signup required.
 - [Toolshref ZOD Schema Generator](https://toolshref.com/json-to-zod-schema-generator/) - Generate JSON to TypeScript Zod validation schemas instantly.
 - [Tools-Online Cron Generator](https://www.tools-online.app/tools/cron) - Visual cron expression builder with real-time preview and plain English descriptions. 100% client-side.


### PR DESCRIPTION
## Adding UUID Generator

**Tool:** [UUID Generator](https://freedevtool.org/uuid-generator)

### Why this fits the list

1. ✅ **Browser-based** — uses `crypto.randomUUID()` (Web Crypto CSPRNG); no native install
2. ✅ **Direct link** — opens straight to the UUID generator tool (not a multi-tool landing)
3. ✅ **100% free** — no signup, no trial, no paywall, no usage limit

### Why this fills a gap

I checked the existing list and noticed there's no UUID generator in the **Generators** section. UUIDs are a universal developer need, and the modern UUIDv7 (RFC 9562, finalized May 2024) is becoming the default for database primary keys.

### Features
- Supports v1 (timestamp + MAC), v4 (random), v5 (deterministic), v7 (time-ordered)
- Bulk generation up to 1,000 UUIDs
- One-click copy or download as .txt
- Browser-only — IDs never sent to a server
- Side-by-side byte layout view for v1/v4/v7 comparison

Thanks for maintaining this curated list!