### PR TITLE
Add har2sdk to Generators

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [Tools-Online Cron Generator](https://www.tools-online.app/tools/cron) - Visual cron expression builder with real-time preview and plain English descriptions. 100% client-side.
 - [ToolSparkr Password Generator](https://toolsparkr.com/password-generator) - Generate strong random passwords up to 128 characters with strength indicator. 100% client-side, no data sent to servers.
 - [ToolSparkr QR Code Reader](https://toolsparkr.com/qr-code-reader) - Generate and read QR codes online with adjustable size and error correction. Runs entirely in browser.
+- [har2sdk](https://har2sdk.vercel.app/) - Paste a browser HAR file and generate a typed TypeScript fetch SDK with semantic method names, resource grouping, and auth detection. 100% free, no signup, secret-scrub before upload.
 
 ### Image
 


### PR DESCRIPTION
Adds [har2sdk](https://har2sdk.vercel.app/) to the `Web-based Tools → Generators` section.

Browser-based, direct link, free, no signup — meets the contributing rules in CONTRIBUTING.md.

har2sdk takes a browser HAR file (DevTools → Network → Save all as HAR), runs client-side secret-redaction (Authorization / X-API-Key / JWT / AWS key prefixes are stripped in-browser before any network call), then generates a typed TypeScript fetch SDK with semantic method names, resource grouping, and auth detection.

- Live URL: https://har2sdk.vercel.app/
- Source: https://github.com/SolvoHQ/har2sdk

Note on usage: free LLM call backs the generation, so there is a soft 20-generations/hour/IP rate limit. The tool itself requires no signup, no payment, no account.