### PR TITLE
Add decode64.com — browser-only Base64 decoder & encoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [ToolSparkr Base64 Encoder](https://toolsparkr.com/base64-encoder) - Encode and decode Base64 strings with URL-safe option and file support. 100% client-side.
 - [ToolSparkr JSON Formatter](https://toolsparkr.com/json-validator-beautifier) - Validate, format and beautify JSON data with error line reporting. Runs entirely in browser.
 - [ToolSparkr URL Encoder](https://toolsparkr.com/url-encoder) - Encode and decode URLs with parameter parsing table. 100% client-side, no data sent to servers.
+- [decode64](https://decode64.com) - Free Base64 decoder and encoder. Runs entirely in the browser — no server, no uploads, safe for API keys and JWT tokens.
 - [Sucrase](https://sucrase.io) - Super-fast Babel alternative
 - [SWC](https://swc.rs/playground) - compile JS/TS files using modern JS features and outputs valid code that is supported by all major browsers.
 - [Terser](https://try.terser.org/) - JavaScript parser, mangler and compressor toolkit for ES6+


### PR DESCRIPTION
Adding [decode64.com](https://decode64.com) to the Transformation section.

**Why it fits:**
- Free Base64 decoder/encoder — no server-side processing
- Runs 100% in the browser using native `atob()` / `btoa()`
- Supports Base64URL (JWT tokens), file drag-and-drop, UTF-8
- Single HTML file, zero dependencies, open source

Source: https://github.com/zenopanda705-png/base64-decoder
