### PR TITLE
Add AllTools Regex Visualizer to Regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 
 ### Regex
 
+- [AllTools Regex Visualizer](https://alltools.dev/tools/tech/regex-visualizer/) - Railroad diagrams for regular expressions, with live match and capture-group highlighting. Free, client-side, no signup.
 - [ByteTools Regex Test](https://bytetools.io/regex-tester/) - Free regex test tool with real-time matching, examples, and mobile optimization.
 - [Debuggex](https://www.debuggex.com/) - PCRE/Python/JavaScript regex matching.
 - [ExtendsClass](https://extendsclass.com/regex-tester.html) - PHP/Python/Ruby/JavaScript regex matching.


### PR DESCRIPTION
Adds a regex railroad-diagram visualizer to the Regex section: https://alltools.dev/tools/tech/regex-visualizer/

Paste a pattern and it renders a railroad diagram (groups, alternation, quantifiers, assertions) plus live matching with capture-group highlighting against test text. Web-based, free, no signup, runs entirely client-side. Disclosure: I'm the author.