### PR TITLE
Add JSONViewerTool

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [JSONFormatOnline](https://jsonformatonline.com) - Format, validate and convert JSON locally in the browser, no data sent to servers.
 - [JSON ABC](https://novicelab.org/jsonabc/) - Sorts JSON alphabetically
 - [JSON Formatter & Validator](https://devtoollab.com/tools/json-formatter) - Format, validate and beautify JSON data
+- [JSONViewerTool](https://jsonviewertool.com/) - View, format, validate, minify and convert JSON (CSV/YAML/XML) in the browser, fully client-side.
 - [JSON to XML Converter](https://devtoollab.com/tools/json-to-xml) - Convert JSON data to XML format with proper formatting and structure
 - [CSV to JSON & JSON to CSV](https://devtoollab.com/tools/csv-json-converter) - Convert between CSV and JSON formats
 - [Markdown to HTML](https://markdowntohtml.com) - Paste or type your markdown and see it rendered as HTML. Download or copy the resulting HTML.


### PR DESCRIPTION
Adds [JSONViewerTool](https://jsonviewertool.com/) to the **Transformation** section, alongside the other in-browser JSON format/validate/convert tools (JSONFormatOnline, Sovereign JSON Toolkit, etc.).

It's a free, 100% client-side suite: JSON viewer, formatter, validator, minifier, and JSON↔CSV/YAML/XML converters. No signup and no uploads — everything runs in the browser.

Thanks for maintaining the list!