### PR TITLE
Add CSS Flex Generator to Generators

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [ColorForge](https://simplereally.github.io/color-forge/) - Generate color palettes with real-time preview, CSS/SCSS export, and shareable URLs.
 - [CORS Header Generator](https://puredevtools.tools/cors-header-generator/) - Generate CORS headers for your API with visual configuration. 100% client-side, no data sent to server.
 - [CSS Filter Generator](https://puredevtools.tools/css-filter-generator/) - Compose CSS filter effects (blur, brightness, contrast, grayscale) with real-time preview. Runs entirely in browser.
+- [CSS Flex Generator](https://codequest.work/generator/flex/) - Visually configure CSS Flexbox properties with real-time preview and copy the generated CSS. Runs entirely in browser.
 - [har2sdk](https://har2sdk.vercel.app/) - Paste a browser HAR file and generate a typed TypeScript fetch SDK with semantic method names, resource grouping, and auth detection.
 - [JSONGenerator](https://www.jsongenerator.io) - Create random JSON data
 - [MetaForge](https://simplereally.github.io/meta-forge/) - Preview meta tags for Google, Facebook, and Twitter before publishing.


### PR DESCRIPTION
Another fresh single-line PR for one of the CSS layout generators you mentioned on #357.

- [CSS Flex Generator](https://codequest.work/generator/flex/) - Visually configure CSS Flexbox properties with real-time preview and copy the generated CSS. Runs entirely in browser.

Meets CONTRIBUTING.md:
- **Browser-based** — runs entirely client-side
- **Direct link** — goes straight to the single tool (not a landing page)
- **100% free** — no signup, trial, paywall, or usage limits

Placed in alphabetical order in the Generators section (after CSS Filter Generator). Thanks!