### PR TITLE
Add AI Background Remover to Image

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 
 ### Image
 
+- [AI Background Remover](https://codequest.work/generator/bg-remover/) - Automatically detect the subject and remove image backgrounds with AI, entirely in the browser.
 - [ASCII Silhouettify](https://meatfighter.com/ascii-silhouettify/spa) - Convert images into ANSI-escaped color ASCII art.
 - [Favic-o-matic](http://www.favicomatic.com/) - Literally generates every favicon neccessary + markup.
 - [JPEG.rocks](https://jpeg.rocks) - Privacy-aware JPEG optimizer


### PR DESCRIPTION
Following your note on #376, this is a fresh single-line PR for just one tool (not a bundle), and it doesn't duplicate an existing entry.

- [AI Background Remover](https://codequest.work/generator/bg-remover/) - Automatically detect the subject and remove image backgrounds with AI, entirely in the browser.

Meets CONTRIBUTING.md:
- **Browser-based** — AI runs fully client-side, no image is uploaded to a server
- **Direct link** — goes straight to the single tool (not a landing page)
- **100% free** — no signup, trial, paywall, or usage limits

Placed in alphabetical order at the top of the Image section. Thanks for the earlier feedback!