### PR TITLE
Add DiffsHub to Diffing

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 
 - [ApiNotes](https://apinotes.io/openapi-diff) - Compare two OpenAPI 3.x & Swagger 2.0 specifications side by side. Detect breaking changes, added/removed endpoints, and parameter diffs.
 - [Diff Text](https://difftext.com/) - Quickly highlight differences in plain text, code, or JSON files.
+- [DiffsHub](https://diffshub.com/) - View any public GitHub diff (PRs, commits, comparisons, patches) in a fast, virtualized interface by swapping github.com for diffshub.com.
 - [JSONDiffPatch](https://benjamine.github.io/jsondiffpatch) - Run a visual or non-visual diff on two JSON blobs.
 
 ### File Sharing


### PR DESCRIPTION
## Summary

Adds **[DiffsHub](https://diffshub.com/)** to the `Diffing` section.

View any public GitHub diff (PRs, commits, comparisons, patches) in a fast, virtualized interface by swapping `github.com` for `diffshub.com`. Browser-based, free, and a direct link per CONTRIBUTING.md. Placed alphabetically between `Diff Text` and `JSONDiffPatch`.

## Test plan

- [ ] Lychee link-check CI passes
- [ ] Entry renders correctly under Diffing