### PR TITLE
Add CodeQuest Diff Checker to Diffing

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 ### Diffing
 
 - [ApiNotes](https://apinotes.io/openapi-diff) - Compare two OpenAPI 3.x & Swagger 2.0 specifications side by side. Detect breaking changes, added/removed endpoints, and parameter diffs.
+- [CodeQuest Diff Checker](https://codequest.work/generator/diff-checker/) - Compare code or text differences in the browser with character-level highlighting of added, changed, and removed lines. Detects full-width spaces. 100% client-side, no signup.
 - [Diff Text](https://difftext.com/) - Quickly highlight differences in plain text, code, or JSON files.
 - [JSONDiffPatch](https://benjamine.github.io/jsondiffpatch) - Run a visual or non-visual diff on two JSON blobs.
 


### PR DESCRIPTION
Adds **CodeQuest Diff Checker** (https://codequest.work/generator/diff-checker/) to the **Diffing** section.

- **Browser-based** — runs entirely client-side, no installs
- **Direct link** — single-purpose tool page (not a multi-tool landing page)
- **100% free** — no signup, trial, paywall, or usage limits