### PR TITLE
Add ThisDevTool Regex Tester to Regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [ExtendsClass](https://extendsclass.com/regex-tester.html) - PHP/Python/Ruby/JavaScript regex matching.
 - [Regexr](http://www.regexr.com/) - JavaScript regex matching.
 - [Regulex](https://jex.im/regulex) - JavaScript Regular Expression Visualizer.
+- [ThisDevTool Regex Tester](https://thisdevtool.com/tools/regex-tester) - Live JavaScript regex tester with real-time match highlighting, flags, and capture groups. 100% client-side.
 
 ### Transformation
 


### PR DESCRIPTION
Adds [ThisDevTool Regex Tester](https://thisdevtool.com/tools/regex-tester) to the Regex section.

Meets the contribution rules:
- **Browser-based** — runs entirely client-side, no download
- **Direct link** — goes straight to the single tool, not a landing page
- **100% free** — no signup, trial, paywall, or usage limit

It offers real-time match highlighting, regex flags, capture-group breakdown, and replace, alongside the existing Debuggex/Regexr/Regulex entries. Thanks for maintaining the list!