### PR TITLE
Add Website Cost Data to Resources > APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 
 - [API Status Check](https://www.apistatuscheck.com) - Real-time status monitoring for 540+ APIs and services including AWS, Stripe, GitHub, and OpenAI.
 - [JSONPlaceholder](https://jsonplaceholder.typicode.com) - Free fake API for testing and prototyping.
+- [Website Cost Data](https://projectcostestimator.com/api-docs) - Free CC BY 4.0 JSON benchmarks for web-project costs (build, hosting, TCO, hourly rates) by platform and market. No key needed.
 - [Zippopotamus](http://zippopotam.us/) - Zipcode to Geo
 
 ### Browser Information


### PR DESCRIPTION
Adds one entry to Resources > APIs (alphabetical position, matches existing format).

**Website Cost Data** — https://projectcostestimator.com/api-docs
JSON benchmarks for web-project costs (build cost, hosting, 3-year TCO, hourly-rate ranges) by platform (WordPress, Shopify, WooCommerce, Magento, custom) and geographic market. Licensed CC BY 4.0.

Against the contribution notes:
- Browser-based: yes — docs page + a plain JSON endpoint (`/api/cost-data`), nothing to install
- Direct link: yes — goes straight to the API docs
- 100% free: yes — no signup, no key, no usage limits; verified before submitting (HTTPS 200, `Access-Control-Allow-Origin: *`, no auth)

Disclosure: I built this API/dataset.
