### PR TITLE
Add cURL to Fetch to Transformation

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [ByteTools URL Encoder](https://bytetools.io/url-encoder/) - Encode and decode URLs safely. Perfect for handling query parameters and API endpoints.
 - [Compiler Explorer](https://godbolt.org) - Run compilers interactively from your web browser and interact with the assembly
 - [CSV to JSON & JSON to CSV](https://devtoollab.com/tools/csv-json-converter) - Convert between CSV and JSON formats
+- [cURL to Fetch](https://alltoolsverse.com/tools/curl-to-fetch/) - Convert cURL commands to browser fetch, TypeScript fetch, Axios, or node-fetch code entirely client-side.
 - [EpochPilot](https://epochpilot.com) - Convert Unix timestamps, compare timezones, and parse cron expressions. 100% client-side.
 - [fixmyjs](http://goatslacker.github.io/fixmyjs.com/) - Automatically fix your JS, driven by JSHint.
 - [JavaScript Deobfuscator](https://deobfuscate.io) - A simple but powerful deobfuscator to remove common JavaScript obfuscation techniques.


### PR DESCRIPTION
Adds cURL to Fetch to the Transformation section.

The tool converts cURL commands to browser fetch, TypeScript fetch, Axios, or node-fetch code. It runs entirely client-side, is free to use, and requires no signup.

Link: https://alltoolsverse.com/tools/curl-to-fetch/

Disclosure: I am the developer of All Tools Verse.