### PR TITLE
Add GitHub Actions Node 24 Checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 
 - [Ada URL Parser](https://playground.ada-url.com/?url=torrent://blog/post/1?source|rest=rss) - WHATWG-compliant and fast URL parser written in modern C++, online.
 - [CSP Evaluator](https://csp-evaluator.withgoogle.com) - Evaluate CSP rules
+- [GitHub Actions Node 24 Checker](https://yunczo.github.io/ci-rescue-service/tools/github-actions-node24-checker.html) - Check workflow YAML for Node 24 migration review points locally in the browser.
 - [numverify](https://numverify.com/) - Validate phone numbers from over 200 countries.
 - [OpenAPI Validator](https://apinotes.io/openapi-validator) - Validate OpenAPI 3.1, 3.0 & Swagger 2.0 specifications. Paste JSON/YAML, upload files, or fetch from URL.
 - [Pythonium](https://pythonium.net/linter) - Validate Python code.


### PR DESCRIPTION
Adds one alphabetized entry under Resources > Validation & Parsers.

The checker is free and solely web-based; it requires no account, download, or installation. It analyzes pasted workflow YAML locally in the browser, and its CSP blocks network requests.

Disclosure: I maintain CI Rescue and am submitting my own checker.

Checks: direct URL returns HTTP 200; `git diff --check` passes.