### PR TITLE
Add SammaPix EXIF Remover to Image

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [Favic-o-matic](http://www.favicomatic.com/) - Literally generates every favicon neccessary + markup.
 - [JPEG.rocks](https://jpeg.rocks) - Privacy-aware JPEG optimizer
 - [PNG-to-SVG](https://png-to-svg.com) - Free conversion from JPG or PNG images To vectorized SVG.
+- [SammaPix EXIF Remover](https://www.sammapix.com/tools/exif) - Strip EXIF/GPS metadata from images in the browser, nothing is uploaded.
 - [Squoosh](https://squoosh.app/) - Compress and optimize images in browser
 - [SVG-to-backgroundImage](https://csspro.com/svg-to-background-image-css) - Convert your SVG files into CSS url (data URIs) by encoding it.
 - [SVGOMG](https://jakearchibald.github.io/svgomg/) - Try [SVGO](https://github.com/svg/svgo) (SVG Optimizer) in the browser!


### PR DESCRIPTION
Adds one entry to **### Image**, alphabetically before Squoosh.

Against the contribution criteria:
- **Browser-based** — metadata is stripped locally with Canvas/WASM; DevTools shows no upload requests during processing.
- **Direct link** — https://www.sammapix.com/tools/exif goes straight to the tool, not a landing page.
- **Free** — no signup, no watermark, no paywall for this tool. Full disclosure: the free tier processes up to 20 files per batch and there is an optional paid plan for larger batches, so feel free to close this if that counts as a usage limit for the list.

Useful for developers scrubbing GPS/EXIF out of screenshots and photos before publishing them.