### PR TITLE
Add gottrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 
 - [ASCII Silhouettify](https://meatfighter.com/ascii-silhouettify/spa) - Convert images into ANSI-escaped color ASCII art.
 - [Favic-o-matic](http://www.favicomatic.com/) - Literally generates every favicon neccessary + markup.
+- [gottrix](https://gottrix.app/en/heic-to-jpg) - Free browser-based image converter (HEIC, WebP, AVIF, PNG, JPEG, and more), part of a larger 500+ tool client-side file-conversion suite. 100% client-side via WebAssembly.
 - [JPEG.rocks](https://jpeg.rocks) - Privacy-aware JPEG optimizer
 - [PNG-to-SVG](https://png-to-svg.com) - Free conversion from JPG or PNG images To vectorized SVG.
 - [Squoosh](https://squoosh.app/) - Compress and optimize images in browser


### PR DESCRIPTION
Adding gottrix (https://gottrix.app): browser-based, 100% client-side, no signups/trials/paywalls/usage limits - matches this list's own stated criteria. Free image converter (HEIC, WebP, AVIF, PNG, JPEG and more), part of a larger 500+ tool file-conversion suite via WebAssembly. Closed-source, free to use. I'm the maintainer, disclosing that here.