### PR TITLE
Add JSON Formatter to Transformation

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [fixmyjs](http://goatslacker.github.io/fixmyjs.com/) - Automatically fix your JS, driven by JSHint.
 - [JavaScript Deobfuscator](https://deobfuscate.io) - A simple but powerful deobfuscator to remove common JavaScript obfuscation techniques.
 - [JSON ABC](https://novicelab.org/jsonabc/) - Sorts JSON alphabetically
+- [JSON Formatter](https://jsontools.space/tools/json-formatter) - Format, validate, and minify JSON with inline error highlighting. 100% client-side.
 - [JSONFormatOnline](https://jsonformatonline.com) - Format, validate and convert JSON locally in the browser, no data sent to servers.
 - [Markdown to HTML](https://markdowntohtml.com) - Paste or type your markdown and see it rendered as HTML. Download or copy the resulting HTML.
 - [Markdown Tools](https://markdowntools.com) - Tools to convert Markdown to/from a number of formats. E.g. Html to Markdown, or a CSV to a Markdown table.


### PR DESCRIPTION
Adds the JSON Formatter tool from [JSON Tools](https://jsontools.space/) to the Transformation section.

Direct link to the single-purpose formatter/validator page (not the site's homepage), per the contribution notes. Browser-based, 100% client-side, no signup.