### PR TITLE
Add Nutilz Cron Builder to Generators

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [JSONGenerator](https://www.jsongenerator.io) - Create random JSON data
 - [Mockium](https://softwium.com/mockium/) - Create test data
 - [NGINXConfig](https://www.digitalocean.com/community/tools/nginx) - The easiest way to configure a performant, secure, and stable NGINX server.
+- [Nutilz Cron Builder](https://nutilz.com/cron-builder) - Visually build and validate cron expressions with presets, a plain-English schedule description, and a preview of the next 10 run times.
 - [Pictera](https://pictera.co) - Generate beautiful Open Graph images with no design skills required.
 - [UUID Generator](https://freedevtool.org/uuid-generator) - Generate UUID v1, v4, v5, or v7 (RFC 9562) in browser. Bulk generation up to 1,000. Uses Web Crypto CSPRNG.
 


### PR DESCRIPTION
Adds [Nutilz Cron Builder](https://nutilz.com/cron-builder) to the Generators section.

What it does: a visual, point-and-click cron expression builder — pick minute/hour/day/month/weekday values (or start from a preset like `@daily` / `@weekly` / `every 15 min`), get the generated cron syntax plus a plain-English description of the schedule, and preview the next 10 run times. Also validates hand-written cron expressions.

Meets the contribution notes: browser-based (all parsing/validation runs client-side, no server round-trip), direct link straight to the tool, 100% free with no signup/paywall/usage limits.