### PR TITLE
Add HTTP Status Codes to Cheat Sheets section

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 
 ### Cheat Sheets
 
+- [HTTP Status Codes](https://nutilz.com/http-status-codes) - Searchable reference for all standard HTTP response codes (1xx-5xx) with plain-English descriptions, free and no signup.
 - [OWASP Cheat Sheet Series](https://cheatsheetseries.owasp.org) - A concise collection of high value information on specific application security topics.
 
 ### CSS Inliners


### PR DESCRIPTION
Adds [nutilz.com/http-status-codes](https://nutilz.com/http-status-codes), a free, searchable reference for all standard HTTP response codes (1xx informational through 5xx server error) with plain-English descriptions for each -- useful for debugging APIs, server logs, and web apps. Browser-based, no signup, no paywall, direct link per the contribution notes.