### PR TITLE
Add Nutilz Chmod Calculator to Generators

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [JSONGenerator](https://www.jsongenerator.io) - Create random JSON data
 - [Mockium](https://softwium.com/mockium/) - Create test data
 - [NGINXConfig](https://www.digitalocean.com/community/tools/nginx) - The easiest way to configure a performant, secure, and stable NGINX server.
+- [Nutilz Chmod Calculator](https://nutilz.com/chmod-calculator) - Visually toggle read/write/execute permissions for owner, group, and others and get the numeric (e.g. 755) and symbolic (e.g. rwxr-xr-x) chmod codes, plus the ready-to-run command.
 - [Pictera](https://pictera.co) - Generate beautiful Open Graph images with no design skills required.
 - [UUID Generator](https://freedevtool.org/uuid-generator) - Generate UUID v1, v4, v5, or v7 (RFC 9562) in browser. Bulk generation up to 1,000. Uses Web Crypto CSPRNG.
 


### PR DESCRIPTION
Adds [Nutilz Chmod Calculator](https://nutilz.com/chmod-calculator) — a free, no-signup tool that visually toggles read/write/execute permissions for owner, group, and others and outputs the numeric (e.g. 755) and symbolic (e.g. rwxr-xr-x) chmod codes plus a ready-to-run command. Placed alphabetically in the Generators section.