### PR TITLE
Add TryQuickImg and TryDevSnip

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 
 - [crontab guru](https://crontab.guru/) - The quick and simple editor for cron schedule expressions by Cronitor
 - [Devtools Tips](https://devtoolstips.org) - Copy-and-paste'able collection of useful cross-browser DevTools snippets.
-- [TryDevSnip](https://trydevsnip.com/) - Browser-only JSON/cron/timestamp/JWT/hash tools — paste stays in the tab, no upload for processing.
+- [TryDevSnip JSON Formatter](https://trydevsnip.com/json-formatter/) - Format/validate JSON in the browser — paste stays in the tab, no upload for processing.
 
 ### CSS
 
@@ -85,7 +85,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [Squoosh](https://squoosh.app/) - Compress and optimize images in browser
 - [SVG-to-backgroundImage](https://csspro.com/svg-to-background-image-css) - Convert your SVG files into CSS url (data URIs) by encoding it.
 - [SVGOMG](https://jakearchibald.github.io/svgomg/) - Try [SVGO](https://github.com/svg/svgo) (SVG Optimizer) in the browser!
-- [TryQuickImg](https://tryquickimg.com/) - Browser-only image tools: HEIC→JPG, compress to a KB target, resize, crop, QR — files stay on-device.
+- [TryQuickImg HEIC to JPG](https://tryquickimg.com/heic-to-jpg/) - Convert HEIC/HEIF to JPG in the browser — file stays on-device, no signup.
 
 ### Performance
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 
 - [crontab guru](https://crontab.guru/) - The quick and simple editor for cron schedule expressions by Cronitor
 - [Devtools Tips](https://devtoolstips.org) - Copy-and-paste'able collection of useful cross-browser DevTools snippets.
+- [TryDevSnip](https://trydevsnip.com/) - Browser-only JSON/cron/timestamp/JWT/hash tools — paste stays in the tab, no upload for processing.
 
 ### CSS
 
@@ -84,6 +85,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [Squoosh](https://squoosh.app/) - Compress and optimize images in browser
 - [SVG-to-backgroundImage](https://csspro.com/svg-to-background-image-css) - Convert your SVG files into CSS url (data URIs) by encoding it.
 - [SVGOMG](https://jakearchibald.github.io/svgomg/) - Try [SVGO](https://github.com/svg/svgo) (SVG Optimizer) in the browser!
+- [TryQuickImg](https://tryquickimg.com/) - Browser-only image tools: HEIC→JPG, compress to a KB target, resize, crop, QR — files stay on-device.
 
 ### Performance
 


### PR DESCRIPTION
## Summary
Adds two browser-only tool sites to the curated list.

- **TryQuickImg** (Image) — HEIC→JPG, compress-to-KB, resize, crop, QR; processing stays on-device.
- **TryDevSnip** (Copy/Paste Scripts & Styles) — JSON, cron, timestamps, JWT, hash; paste stays in the tab.

## Affiliation
I am the maker of both sites (Samson PG / Acsaven).

## Test plan
- [x] Links resolve
- [x] Tools usable without signup for core features